### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/finger_tree/README
+++ b/finger_tree/README
@@ -1,5 +1,5 @@
 This is an implementation of 2-3 finger trees by Ralf Hinze and Ross
-Paterson ( http://www.soi.city.ac.uk/~ross/papers/FingerTree.html ).
+Paterson ( https://staff.city.ac.uk/~ross/papers/FingerTree.html ).
 The variety of uses of this data structure by varying the monoid
 implementation is impressive. However, be aware that the core
 implementation, whilst it does obey the general O(log) performance

--- a/finger_tree/src/finger_tree.erl
+++ b/finger_tree/src/finger_tree.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -35,7 +35,7 @@
 %% implementation to vary. See the paper[0] for examples of other
 %% things that could be implemented.
 %%
-%% [0]: http://www.soi.city.ac.uk/~ross/papers/FingerTree.html
+%% [0]: https://staff.city.ac.uk/~ross/papers/FingerTree.html
 
 
 -compile([export_all]).

--- a/finger_tree/src/ft_queue.erl
+++ b/finger_tree/src/ft_queue.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/finger_tree/src/ordered_sequence.erl
+++ b/finger_tree/src/ordered_sequence.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/finger_tree/src/ordered_sequence_map.erl
+++ b/finger_tree/src/ordered_sequence_map.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/finger_tree/src/priority_queue.erl
+++ b/finger_tree/src/priority_queue.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/fqueue/src/fqueue.erl
+++ b/fqueue/src/fqueue.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.mozilla.org/MPL/ with 7 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://www.soi.city.ac.uk/~ross/papers/FingerTree.html (301) with 2 occurrences migrated to:  
  https://staff.city.ac.uk/~ross/papers/FingerTree.html ([https](https://www.soi.city.ac.uk/~ross/papers/FingerTree.html) result 302).